### PR TITLE
CF-340: add default region

### DIFF
--- a/src/main/resources/feeds_archives.schema.orderly
+++ b/src/main/resources/feeds_archives.schema.orderly
@@ -3,8 +3,7 @@ object {
     array [
         string [ "JSON", "XML" ];
     ] {1,2} data_format;
-    string  default_region?;
-    string  default_container_name = "FeedsArchives"?;
+    string  default_archive_container_url?;
     object {
         string iad;
         string ord;

--- a/src/main/resources/feeds_archives.schema.orderly
+++ b/src/main/resources/feeds_archives.schema.orderly
@@ -3,6 +3,7 @@ object {
     array [
         string [ "JSON", "XML" ];
     ] {1,2} data_format;
+    string  default_region?;
     string  default_container_name = "FeedsArchives"?;
     object {
         string iad;

--- a/src/main/resources/sql/schema/V1.2__data_feeds_archives.sql
+++ b/src/main/resources/sql/schema/V1.2__data_feeds_archives.sql
@@ -1,7 +1,7 @@
 insert
   into "preferences_metadata" ("slug", "description", "schema")
 values ('archive',
-        'Cloud feeds Archive Preferences',
+        'Cloud Feeds Archive Preferences',
         'object {
             boolean enabled;
             array [

--- a/src/main/resources/sql/schema/V1.2__data_feeds_archives.sql
+++ b/src/main/resources/sql/schema/V1.2__data_feeds_archives.sql
@@ -7,6 +7,7 @@ values ('archive',
             array [
               string [ "JSON", "XML" ];
             ] {1,2} data_format;
+            string  default_region?;
             string  default_container_name = "FeedsArchives"?;
             object {
               string iad;

--- a/src/main/resources/sql/schema/V1.2__data_feeds_archives.sql
+++ b/src/main/resources/sql/schema/V1.2__data_feeds_archives.sql
@@ -7,8 +7,7 @@ values ('archive',
             array [
               string [ "JSON", "XML" ];
             ] {1,2} data_format;
-            string  default_region?;
-            string  default_container_name = "FeedsArchives"?;
+            string  default_archive_container_url?;
             object {
               string iad;
               string ord;


### PR DESCRIPTION
Per mockup, we are supposed to support the notion of a basic customer configuration where all feeds archive is going to one region and one container. To do this we would need Reach to tell us which one is the default region. 